### PR TITLE
BMT hit process: fix to z coordinate used to determine strip, to be c…

### DIFF
--- a/4.4.2/source/hitprocess/clas12/micromegas/BMT_hitprocess.cc
+++ b/4.4.2/source/hitprocess/clas12/micromegas/BMT_hitprocess.cc
@@ -175,8 +175,8 @@ vector<identifier>  BMT_HitProcess :: processID(vector<identifier> id, G4Step* a
 	int sector = yid[2].id;
 	G4ThreeVector   xyz  = aStep->GetPostStepPoint()->GetPosition();  ///< Global Coordinates of interaction
 	G4ThreeVector  lxyz  = aStep->GetPreStepPoint()->GetTouchableHandle()->GetHistory()->GetTopTransform().TransformPoint(xyz); ///< Local Coordinates of interaction
-	double dz = bmtc.Z + aStep->GetPreStepPoint()->GetPhysicalVolume()->GetTranslation().z();
-	lxyz.setZ(lxyz.z()+dz);
+	double z0 = bmtc.ZMIN[layer-1]+Detector.dimensions[2];
+	lxyz.setZ(lxyz.z()+z0);
 
 	// if the scale is not set, then use fieldmanager to get the value
 	// if fieldmanager is not found, the field is zero

--- a/4.4.2/source/hitprocess/clas12/micromegas/bmt_strip.h
+++ b/4.4.2/source/hitprocess/clas12/micromegas/bmt_strip.h
@@ -44,7 +44,6 @@ public:
 	const static int NSECTORS = 3  ;	// 3 tiles per layer of MM
 
 	// Detector geometrical characteristics
-	double Z=-94.7;                // matches ideal position of BMT mother volume
 	double RADIUS[NLAYERS] ; 	// the radius of the Z detector in mm
 	int AXIS[NLAYERS] ;             // 0 if C-detector, 1 if Z detector
 	int NSTRIPS[NLAYERS] ; 	       // the number of strips


### PR DESCRIPTION
…ompatible with shifts of both mother volume and individual sub-volumes